### PR TITLE
Fix module path to use full GitHub path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ The main objective of this tool is to automate the often tedious process of gath
 
 ### Installation
 
+**Option 1: Direct Installation (Recommended)**
+
+Install the latest version directly from GitHub:
+
+```bash
+go install github.com/Sriram-PR/doc-scraper/cmd/crawler@latest
+```
+
+This installs the `crawler` binary to your `GOPATH/bin` directory (usually `~/go/bin` or `%USERPROFILE%\go\bin`). Make sure this directory is in your `PATH`.
+
+**Option 2: Clone and Build**
+
 1. **Clone the repository:**
 
    ```bash

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -20,13 +20,13 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/crawler"
-	"doc-scraper/pkg/fetch"
-	"doc-scraper/pkg/orchestrate"
-	"doc-scraper/pkg/storage"
-	"doc-scraper/pkg/utils"
-	"doc-scraper/pkg/watch"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/crawler"
+	"github.com/piratf/doc-scraper/pkg/fetch"
+	"github.com/piratf/doc-scraper/pkg/orchestrate"
+	"github.com/piratf/doc-scraper/pkg/storage"
+	"github.com/piratf/doc-scraper/pkg/utils"
+	"github.com/piratf/doc-scraper/pkg/watch"
 )
 
 const version = "1.1.0"

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -20,13 +20,13 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/crawler"
-	"github.com/piratf/doc-scraper/pkg/fetch"
-	"github.com/piratf/doc-scraper/pkg/orchestrate"
-	"github.com/piratf/doc-scraper/pkg/storage"
-	"github.com/piratf/doc-scraper/pkg/utils"
-	"github.com/piratf/doc-scraper/pkg/watch"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/crawler"
+	"github.com/Sriram-PR/doc-scraper/pkg/fetch"
+	"github.com/Sriram-PR/doc-scraper/pkg/orchestrate"
+	"github.com/Sriram-PR/doc-scraper/pkg/storage"
+	"github.com/Sriram-PR/doc-scraper/pkg/utils"
+	"github.com/Sriram-PR/doc-scraper/pkg/watch"
 )
 
 const version = "1.1.0"

--- a/cmd/crawler/mcp.go
+++ b/cmd/crawler/mcp.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"doc-scraper/pkg/mcp"
+	"github.com/piratf/doc-scraper/pkg/mcp"
 )
 
 // runMcpServer handles the mcp-server subcommand

--- a/cmd/crawler/mcp.go
+++ b/cmd/crawler/mcp.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/piratf/doc-scraper/pkg/mcp"
+	"github.com/Sriram-PR/doc-scraper/pkg/mcp"
 )
 
 // runMcpServer handles the mcp-server subcommand

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/piratf/doc-scraper
+module github.com/Sriram-PR/doc-scraper
 
 go 1.25
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module doc-scraper
+module github.com/piratf/doc-scraper
 
 go 1.25
 

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/piratf/doc-scraper/pkg/utils"
+	"github.com/Sriram-PR/doc-scraper/pkg/utils"
 )
 
 // Validate checks AppConfig fields and applies sensible defaults.

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"doc-scraper/pkg/utils"
+	"github.com/piratf/doc-scraper/pkg/utils"
 )
 
 // Validate checks AppConfig fields and applies sensible defaults.

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/piratf/doc-scraper/pkg/utils"
+	"github.com/Sriram-PR/doc-scraper/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"doc-scraper/pkg/utils"
+	"github.com/piratf/doc-scraper/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -25,15 +25,15 @@ import (
 	"golang.org/x/sync/semaphore"
 	"gopkg.in/yaml.v3"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/fetch"
-	"github.com/piratf/doc-scraper/pkg/models"
-	"github.com/piratf/doc-scraper/pkg/parse"
-	"github.com/piratf/doc-scraper/pkg/process"
-	"github.com/piratf/doc-scraper/pkg/queue"
-	"github.com/piratf/doc-scraper/pkg/sitemap"
-	"github.com/piratf/doc-scraper/pkg/storage"
-	"github.com/piratf/doc-scraper/pkg/utils"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/fetch"
+	"github.com/Sriram-PR/doc-scraper/pkg/models"
+	"github.com/Sriram-PR/doc-scraper/pkg/parse"
+	"github.com/Sriram-PR/doc-scraper/pkg/process"
+	"github.com/Sriram-PR/doc-scraper/pkg/queue"
+	"github.com/Sriram-PR/doc-scraper/pkg/sitemap"
+	"github.com/Sriram-PR/doc-scraper/pkg/storage"
+	"github.com/Sriram-PR/doc-scraper/pkg/utils"
 )
 
 // Crawler orchestrates the web crawling process for a single configured site

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -25,15 +25,15 @@ import (
 	"golang.org/x/sync/semaphore"
 	"gopkg.in/yaml.v3"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/fetch"
-	"doc-scraper/pkg/models"
-	"doc-scraper/pkg/parse"
-	"doc-scraper/pkg/process"
-	"doc-scraper/pkg/queue"
-	"doc-scraper/pkg/sitemap"
-	"doc-scraper/pkg/storage"
-	"doc-scraper/pkg/utils"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/fetch"
+	"github.com/piratf/doc-scraper/pkg/models"
+	"github.com/piratf/doc-scraper/pkg/parse"
+	"github.com/piratf/doc-scraper/pkg/process"
+	"github.com/piratf/doc-scraper/pkg/queue"
+	"github.com/piratf/doc-scraper/pkg/sitemap"
+	"github.com/piratf/doc-scraper/pkg/storage"
+	"github.com/piratf/doc-scraper/pkg/utils"
 )
 
 // Crawler orchestrates the web crawling process for a single configured site

--- a/pkg/fetch/client.go
+++ b/pkg/fetch/client.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"net/http"
 
-	"doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/config"
 
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/fetch/client.go
+++ b/pkg/fetch/client.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
 
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/fetch/fetcher.go
+++ b/pkg/fetch/fetcher.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/utils"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/utils"
 )
 
 // Fetcher handles making HTTP requests with configured retry logic, using an underlying http.Client

--- a/pkg/fetch/fetcher.go
+++ b/pkg/fetch/fetcher.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/utils"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/utils"
 )
 
 // Fetcher handles making HTTP requests with configured retry logic, using an underlying http.Client

--- a/pkg/fetch/fetcher_test.go
+++ b/pkg/fetch/fetcher_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/utils"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/utils"
 )
 
 // testConfig returns an AppConfig with fast retry delays for testing

--- a/pkg/fetch/fetcher_test.go
+++ b/pkg/fetch/fetcher_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/utils"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/utils"
 )
 
 // testConfig returns an AppConfig with fast retry delays for testing

--- a/pkg/fetch/robots.go
+++ b/pkg/fetch/robots.go
@@ -11,7 +11,7 @@ import (
 	"github.com/temoto/robotstxt"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
 )
 
 // SitemapDiscoverer defines the callback interface for handling discovered sitemap URLs

--- a/pkg/fetch/robots.go
+++ b/pkg/fetch/robots.go
@@ -11,7 +11,7 @@ import (
 	"github.com/temoto/robotstxt"
 	"golang.org/x/sync/semaphore"
 
-	"doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/config"
 )
 
 // SitemapDiscoverer defines the callback interface for handling discovered sitemap URLs

--- a/pkg/mcp/handlers.go
+++ b/pkg/mcp/handlers.go
@@ -18,11 +18,11 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"gopkg.in/yaml.v3"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/crawler"
-	"doc-scraper/pkg/fetch"
-	"doc-scraper/pkg/models"
-	"doc-scraper/pkg/storage"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/crawler"
+	"github.com/piratf/doc-scraper/pkg/fetch"
+	"github.com/piratf/doc-scraper/pkg/models"
+	"github.com/piratf/doc-scraper/pkg/storage"
 )
 
 // handleListSites handles the list_sites tool
@@ -95,7 +95,7 @@ func (s *Server) handleGetPage(ctx context.Context, request mcp.CallToolRequest)
 
 	userAgent := s.cfg.AppConfig.DefaultUserAgent
 	if userAgent == "" {
-		userAgent = "doc-scraper/1.0"
+		userAgent = "github.com/piratf/doc-scraper/1.0"
 	}
 	req.Header.Set("User-Agent", userAgent)
 

--- a/pkg/mcp/handlers.go
+++ b/pkg/mcp/handlers.go
@@ -18,11 +18,11 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"gopkg.in/yaml.v3"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/crawler"
-	"github.com/piratf/doc-scraper/pkg/fetch"
-	"github.com/piratf/doc-scraper/pkg/models"
-	"github.com/piratf/doc-scraper/pkg/storage"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/crawler"
+	"github.com/Sriram-PR/doc-scraper/pkg/fetch"
+	"github.com/Sriram-PR/doc-scraper/pkg/models"
+	"github.com/Sriram-PR/doc-scraper/pkg/storage"
 )
 
 // handleListSites handles the list_sites tool
@@ -95,7 +95,7 @@ func (s *Server) handleGetPage(ctx context.Context, request mcp.CallToolRequest)
 
 	userAgent := s.cfg.AppConfig.DefaultUserAgent
 	if userAgent == "" {
-		userAgent = "github.com/piratf/doc-scraper/1.0"
+		userAgent = "github.com/Sriram-PR/doc-scraper/1.0"
 	}
 	req.Header.Set("User-Agent", userAgent)
 

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/sirupsen/logrus"
 
-	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
 )
 
 const (

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/sirupsen/logrus"
 
-	"doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/config"
 )
 
 const (

--- a/pkg/orchestrate/orchestrator.go
+++ b/pkg/orchestrate/orchestrator.go
@@ -9,10 +9,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/crawler"
-	"doc-scraper/pkg/fetch"
-	"doc-scraper/pkg/storage"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/crawler"
+	"github.com/piratf/doc-scraper/pkg/fetch"
+	"github.com/piratf/doc-scraper/pkg/storage"
 )
 
 // SiteResult contains the result of crawling a single site

--- a/pkg/orchestrate/orchestrator.go
+++ b/pkg/orchestrate/orchestrator.go
@@ -9,10 +9,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/crawler"
-	"github.com/piratf/doc-scraper/pkg/fetch"
-	"github.com/piratf/doc-scraper/pkg/storage"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/crawler"
+	"github.com/Sriram-PR/doc-scraper/pkg/fetch"
+	"github.com/Sriram-PR/doc-scraper/pkg/storage"
 )
 
 // SiteResult contains the result of crawling a single site

--- a/pkg/process/content.go
+++ b/pkg/process/content.go
@@ -13,9 +13,9 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/sirupsen/logrus"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/detect"
-	"github.com/piratf/doc-scraper/pkg/utils"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/detect"
+	"github.com/Sriram-PR/doc-scraper/pkg/utils"
 )
 
 // ContentProcessor handles extracting, cleaning, processing (images, links), converting to Markdown, and saving of page content

--- a/pkg/process/content.go
+++ b/pkg/process/content.go
@@ -13,9 +13,9 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/sirupsen/logrus"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/detect"
-	"doc-scraper/pkg/utils"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/detect"
+	"github.com/piratf/doc-scraper/pkg/utils"
 )
 
 // ContentProcessor handles extracting, cleaning, processing (images, links), converting to Markdown, and saving of page content

--- a/pkg/process/content_test.go
+++ b/pkg/process/content_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/config"
 )
 
 // testContentProcessor returns a minimal ContentProcessor for testing

--- a/pkg/process/content_test.go
+++ b/pkg/process/content_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
 )
 
 // testContentProcessor returns a minimal ContentProcessor for testing

--- a/pkg/process/image.go
+++ b/pkg/process/image.go
@@ -21,12 +21,12 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/sirupsen/logrus"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/fetch"
-	"doc-scraper/pkg/models"
-	"doc-scraper/pkg/parse"
-	"doc-scraper/pkg/storage"
-	"doc-scraper/pkg/utils"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/fetch"
+	"github.com/piratf/doc-scraper/pkg/models"
+	"github.com/piratf/doc-scraper/pkg/parse"
+	"github.com/piratf/doc-scraper/pkg/storage"
+	"github.com/piratf/doc-scraper/pkg/utils"
 
 	"golang.org/x/sync/semaphore"
 )

--- a/pkg/process/image.go
+++ b/pkg/process/image.go
@@ -21,12 +21,12 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/sirupsen/logrus"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/fetch"
-	"github.com/piratf/doc-scraper/pkg/models"
-	"github.com/piratf/doc-scraper/pkg/parse"
-	"github.com/piratf/doc-scraper/pkg/storage"
-	"github.com/piratf/doc-scraper/pkg/utils"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/fetch"
+	"github.com/Sriram-PR/doc-scraper/pkg/models"
+	"github.com/Sriram-PR/doc-scraper/pkg/parse"
+	"github.com/Sriram-PR/doc-scraper/pkg/storage"
+	"github.com/Sriram-PR/doc-scraper/pkg/utils"
 
 	"golang.org/x/sync/semaphore"
 )

--- a/pkg/process/links.go
+++ b/pkg/process/links.go
@@ -10,12 +10,12 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/sirupsen/logrus"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/models"
-	"github.com/piratf/doc-scraper/pkg/parse"
-	"github.com/piratf/doc-scraper/pkg/queue"
-	"github.com/piratf/doc-scraper/pkg/storage"
-	"github.com/piratf/doc-scraper/pkg/utils"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/models"
+	"github.com/Sriram-PR/doc-scraper/pkg/parse"
+	"github.com/Sriram-PR/doc-scraper/pkg/queue"
+	"github.com/Sriram-PR/doc-scraper/pkg/storage"
+	"github.com/Sriram-PR/doc-scraper/pkg/utils"
 )
 
 // LinkProcessor handles extracting and queueing links found on a page

--- a/pkg/process/links.go
+++ b/pkg/process/links.go
@@ -10,12 +10,12 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/sirupsen/logrus"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/models"
-	"doc-scraper/pkg/parse"
-	"doc-scraper/pkg/queue"
-	"doc-scraper/pkg/storage"
-	"doc-scraper/pkg/utils"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/models"
+	"github.com/piratf/doc-scraper/pkg/parse"
+	"github.com/piratf/doc-scraper/pkg/queue"
+	"github.com/piratf/doc-scraper/pkg/storage"
+	"github.com/piratf/doc-scraper/pkg/utils"
 )
 
 // LinkProcessor handles extracting and queueing links found on a page

--- a/pkg/queue/priority_queue.go
+++ b/pkg/queue/priority_queue.go
@@ -4,7 +4,7 @@ import (
 	"container/heap"
 	"sync"
 
-	"doc-scraper/pkg/models"
+	"github.com/piratf/doc-scraper/pkg/models"
 
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/queue/priority_queue.go
+++ b/pkg/queue/priority_queue.go
@@ -4,7 +4,7 @@ import (
 	"container/heap"
 	"sync"
 
-	"github.com/piratf/doc-scraper/pkg/models"
+	"github.com/Sriram-PR/doc-scraper/pkg/models"
 
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/queue/priority_queue_test.go
+++ b/pkg/queue/priority_queue_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"doc-scraper/pkg/models"
+	"github.com/piratf/doc-scraper/pkg/models"
 )
 
 // testLogger returns a logger that discards output

--- a/pkg/queue/priority_queue_test.go
+++ b/pkg/queue/priority_queue_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/piratf/doc-scraper/pkg/models"
+	"github.com/Sriram-PR/doc-scraper/pkg/models"
 )
 
 // testLogger returns a logger that discards output

--- a/pkg/sitemap/processor.go
+++ b/pkg/sitemap/processor.go
@@ -16,12 +16,12 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/fetch"
-	"doc-scraper/pkg/models"
-	"doc-scraper/pkg/parse"
-	"doc-scraper/pkg/queue"
-	"doc-scraper/pkg/storage"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/fetch"
+	"github.com/piratf/doc-scraper/pkg/models"
+	"github.com/piratf/doc-scraper/pkg/parse"
+	"github.com/piratf/doc-scraper/pkg/queue"
+	"github.com/piratf/doc-scraper/pkg/storage"
 )
 
 // SitemapProcessor handles fetching, parsing, and processing sitemaps

--- a/pkg/sitemap/processor.go
+++ b/pkg/sitemap/processor.go
@@ -16,12 +16,12 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/fetch"
-	"github.com/piratf/doc-scraper/pkg/models"
-	"github.com/piratf/doc-scraper/pkg/parse"
-	"github.com/piratf/doc-scraper/pkg/queue"
-	"github.com/piratf/doc-scraper/pkg/storage"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/fetch"
+	"github.com/Sriram-PR/doc-scraper/pkg/models"
+	"github.com/Sriram-PR/doc-scraper/pkg/parse"
+	"github.com/Sriram-PR/doc-scraper/pkg/queue"
+	"github.com/Sriram-PR/doc-scraper/pkg/storage"
 )
 
 // SitemapProcessor handles fetching, parsing, and processing sitemaps

--- a/pkg/storage/badger_store.go
+++ b/pkg/storage/badger_store.go
@@ -15,9 +15,9 @@ import (
 	badger "github.com/dgraph-io/badger/v4"
 	"github.com/sirupsen/logrus"
 
-	"github.com/piratf/doc-scraper/pkg/log"
-	"github.com/piratf/doc-scraper/pkg/models"
-	"github.com/piratf/doc-scraper/pkg/utils"
+	"github.com/Sriram-PR/doc-scraper/pkg/log"
+	"github.com/Sriram-PR/doc-scraper/pkg/models"
+	"github.com/Sriram-PR/doc-scraper/pkg/utils"
 )
 
 const (

--- a/pkg/storage/badger_store.go
+++ b/pkg/storage/badger_store.go
@@ -15,9 +15,9 @@ import (
 	badger "github.com/dgraph-io/badger/v4"
 	"github.com/sirupsen/logrus"
 
-	"doc-scraper/pkg/log"
-	"doc-scraper/pkg/models"
-	"doc-scraper/pkg/utils"
+	"github.com/piratf/doc-scraper/pkg/log"
+	"github.com/piratf/doc-scraper/pkg/models"
+	"github.com/piratf/doc-scraper/pkg/utils"
 )
 
 const (

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/piratf/doc-scraper/pkg/models"
+	"github.com/Sriram-PR/doc-scraper/pkg/models"
 )
 
 // PageStore handles page visitation state

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"doc-scraper/pkg/models"
+	"github.com/piratf/doc-scraper/pkg/models"
 )
 
 // PageStore handles page visitation state

--- a/pkg/watch/scheduler.go
+++ b/pkg/watch/scheduler.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/piratf/doc-scraper/pkg/config"
-	"github.com/piratf/doc-scraper/pkg/orchestrate"
+	"github.com/Sriram-PR/doc-scraper/pkg/config"
+	"github.com/Sriram-PR/doc-scraper/pkg/orchestrate"
 )
 
 // Scheduler manages periodic crawling of sites

--- a/pkg/watch/scheduler.go
+++ b/pkg/watch/scheduler.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"doc-scraper/pkg/config"
-	"doc-scraper/pkg/orchestrate"
+	"github.com/piratf/doc-scraper/pkg/config"
+	"github.com/piratf/doc-scraper/pkg/orchestrate"
 )
 
 // Scheduler manages periodic crawling of sites


### PR DESCRIPTION
## Problem
The module path was set to `doc-scraper`, which prevented users from installing the tool directly via:
```bash
go install github.com/Sriram-PR/doc-scraper/cmd/crawler@latest
```

## Solution

- Updated go.mod to use the full GitHub path: github.com/Sriram-PR/doc-scraper
- Updated all import statements across 23 Go files
- README already had the correct installation command

## Changes

- go.mod: module path updated
- All internal imports updated to use the new module path
- No functional changes to the code

## Testing

Verified that the tool can be installed directly from GitHub after this change.