### PR TITLE
Add YAML frontmatter and GitHub-Flavored tables to Markdown output

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The main objective of this tool is to automate the often tedious process of gath
 | **Configurable Crawling** | Uses YAML for global and site-specific settings |
 | **Scope Control** | Limits crawling by domain, path prefix, and disallowed path patterns (regex) |
 | **Content Extraction** | Extracts main content using CSS selectors |
-| **HTML-to-Markdown** | Converts extracted HTML to clean Markdown |
+| **HTML-to-Markdown** | Converts extracted HTML to clean GitHub-Flavored Markdown (tables, task lists, strikethrough) |
 | **Image Handling** | Opt-in downloading and local rewriting of image links with domain and size filtering (disabled by default; doc-scraper is text-first) |
 | **Link Rewriting** | Rewrites internal links to relative paths for local structure |
 | **JSONL Output** | Optional one-record-per-page JSONL with a trailing crawl-summary record, for RAG ingestion |
@@ -44,7 +44,7 @@ The main objective of this tool is to automate the often tedious process of gath
 | **State Persistence** | Uses BadgerDB for state; supports resuming crawls via `crawl --resume` |
 | **Graceful Shutdown** | Handles `SIGINT`/`SIGTERM` with proper cleanup |
 | **HTTP Retries** | Exponential backoff with jitter for transient errors |
-| **Observability** | Structured logging (`logrus`); optional `pprof` endpoint (build with `-tags pprof`) |
+| **Observability** | Structured logging (`log/slog`); optional `pprof` endpoint (build with `-tags pprof`) |
 | **Modular Code** | Organized into packages for clarity and maintainability |
 | **CLI Utilities** | Built-in `config validate` and `config list` commands for configuration management |
 | **MCP Server Mode** | Expose as Model Context Protocol server for Claude Code/Cursor integration |
@@ -384,13 +384,28 @@ When JSONL output is enabled, the crawler also emits `llms.txt` and `llms-full.t
 
 ### Output Format
 
-Each generated Markdown file contains:
+Each generated Markdown file begins with a YAML frontmatter block carrying page metadata, followed by the converted content:
 
-- Original page title as level-1 heading
-- Clean content converted from HTML to Markdown
+- **YAML frontmatter** (delimited by `---`) with `title`, `url` (source URL), `crawled_at` (RFC3339 timestamp), `content_hash` (SHA-256 of the content, matching the JSONL record), and `depth`
+- Clean content converted from HTML to GitHub-Flavored Markdown, preserving tables
 - Relative links to other pages (when within the allowed domain)
 - Local image references (if images are enabled)
-- A footer with metadata including source URL and crawl timestamp
+
+Example:
+
+```markdown
+---
+title: 'Authentication'
+url: https://docs.example.com/api/auth
+crawled_at: "2026-08-09T12:00:00Z"
+content_hash: 9f2b...c1a4
+depth: 2
+---
+
+# Authentication
+
+...page content as Markdown...
+```
 
 ## JSONL Output
 

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -837,7 +837,7 @@ func (c *Crawler) processSinglePageTask(workItem models.WorkItem, workerLog *slo
 	var tempMarkdownBytes []byte
 	var contentErr error
 	// pageTitle and savedContentPath (function-scoped) will be set from these if successful.
-	tempPageTitle, tempSavedPath, tempMarkdownBytes, _, contentErr = c.contentProcessor.ExtractProcessAndSaveContent(originalDoc, finalURL, c.siteCfg, c.siteOutputDir, taskLog, taskCtx)
+	tempPageTitle, tempSavedPath, tempMarkdownBytes, _, contentErr = c.contentProcessor.ExtractProcessAndSaveContent(originalDoc, finalURL, c.siteCfg, c.siteOutputDir, currentDepth, taskLog, taskCtx)
 	if handleTaskError(contentErr) { // If content processing/saving fails, set taskErr and exit.
 		return
 	}

--- a/pkg/crawler/crawler_run_test.go
+++ b/pkg/crawler/crawler_run_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/Sriram-PR/doc-scraper/pkg/config"
 	"github.com/Sriram-PR/doc-scraper/pkg/fetch"
@@ -351,4 +352,75 @@ func TestCrawlerRun_DisallowedPathPatterns(t *testing.T) {
 	assert.NoFileExists(t, filepath.Join(outDir, "secret.md"))
 
 	assert.False(t, rec.wasRequested("/docs/secret.html"), "disallowed-pattern link must not be fetched")
+}
+
+// TestCrawlerRun_FrontmatterAndTables verifies that every saved .md file carries
+// a YAML frontmatter block with page metadata, that its content_hash matches the
+// JSONL record for the same page, and that HTML tables survive as GFM pipe tables
+// (the GitHubFlavored converter plugin is wired up).
+func TestCrawlerRun_FrontmatterAndTables(t *testing.T) {
+	pages := map[string]string{
+		"/docs/index.html": `<html><head><title>Tables Doc</title></head><body>
+			<p>Reference page.</p>
+			<table>
+				<thead><tr><th>Name</th><th>Type</th></tr></thead>
+				<tbody><tr><td>alpha</td><td>string</td></tr></tbody>
+			</table>
+		</body></html>`,
+	}
+	server, _ := newDocServer(t, pages)
+	appCfg := newTestAppConfig(t)
+	siteCfg := baseSiteConfig(server, "/docs/index.html")
+
+	err := runCrawl(t, appCfg, siteCfg)
+	require.NoError(t, err, "Run should succeed")
+
+	outDir := siteOutputDir(appCfg, siteCfg)
+	raw, err := os.ReadFile(filepath.Join(outDir, "index.md"))
+	require.NoError(t, err, "read index.md")
+	fileStr := string(raw)
+
+	require.True(t, strings.HasPrefix(fileStr, "---\n"), "file must start with a frontmatter block")
+	rest := fileStr[len("---\n"):]
+	closeIdx := strings.Index(rest, "\n---\n")
+	require.GreaterOrEqual(t, closeIdx, 0, "frontmatter block must be closed with ---")
+
+	var fm struct {
+		Title       string `yaml:"title"`
+		URL         string `yaml:"url"`
+		CrawledAt   string `yaml:"crawled_at"`
+		ContentHash string `yaml:"content_hash"`
+		Depth       int    `yaml:"depth"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(rest[:closeIdx]), &fm), "parse frontmatter YAML")
+
+	assert.Equal(t, "Tables Doc", fm.Title)
+	assert.Contains(t, fm.URL, "/docs/index.html")
+	assert.Equal(t, 0, fm.Depth, "start URL is depth 0")
+	assert.Len(t, fm.ContentHash, 64, "content_hash should be a hex SHA-256")
+	_, tErr := time.Parse(time.RFC3339, fm.CrawledAt)
+	require.NoError(t, tErr, "crawled_at should be RFC3339")
+
+	body := rest[closeIdx+len("\n---\n"):]
+	assert.Contains(t, body, "|", "GFM pipe tables must be present (tables plugin enabled)")
+	assert.Contains(t, body, "Name")
+	assert.Contains(t, body, "alpha")
+
+	// The frontmatter hash must match the JSONL record's content_hash for the page.
+	jsonlBytes, err := os.ReadFile(filepath.Join(outDir, "pages.jsonl"))
+	require.NoError(t, err, "read pages.jsonl")
+	var jsonlHash string
+	for _, line := range strings.Split(strings.TrimSpace(string(jsonlBytes)), "\n") {
+		if line == "" {
+			continue
+		}
+		var p models.PageJSONL
+		require.NoError(t, json.Unmarshal([]byte(line), &p))
+		if p.RecordType == models.RecordTypePage && strings.Contains(p.URL, "/docs/index.html") {
+			jsonlHash = p.ContentHash
+		}
+	}
+	if jsonlHash != fm.ContentHash {
+		t.Errorf("frontmatter content_hash %q must match JSONL content_hash %q", fm.ContentHash, jsonlHash)
+	}
 }

--- a/pkg/mcp/handlers.go
+++ b/pkg/mcp/handlers.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	md "github.com/JohannesKaufmann/html-to-markdown"
+	"github.com/JohannesKaufmann/html-to-markdown/plugin"
 	"github.com/PuerkitoBio/goquery"
 	"github.com/mark3labs/mcp-go/mcp"
 
@@ -342,16 +343,9 @@ func (s *Server) handleGetPage(ctx context.Context, request mcp.CallToolRequest)
 		return mcp.NewToolResultError(fmt.Sprintf("content selector '%s' not found on page", contentSelector)), nil
 	}
 
-	contentHTML, err := contentSelection.First().Html()
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to extract HTML content: %v", err)), nil
-	}
 	converter := md.NewConverter("", true, nil)
-	content, err := converter.ConvertString(contentHTML)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to convert to markdown: %v", err)), nil
-	}
-	content = strings.TrimSpace(content)
+	converter.Use(plugin.GitHubFlavored())
+	content := strings.TrimSpace(converter.Convert(contentSelection.First()))
 
 	fetchTimeMs := time.Since(startTime).Milliseconds()
 

--- a/pkg/process/content.go
+++ b/pkg/process/content.go
@@ -9,9 +9,12 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	md "github.com/JohannesKaufmann/html-to-markdown"
+	"github.com/JohannesKaufmann/html-to-markdown/plugin"
 	"github.com/PuerkitoBio/goquery"
+	"gopkg.in/yaml.v3"
 
 	"github.com/Sriram-PR/doc-scraper/pkg/config"
 	"github.com/Sriram-PR/doc-scraper/pkg/detect"
@@ -25,16 +28,50 @@ type ContentProcessor struct {
 	appCfg               *config.AppConfig
 	detector             *detect.ContentDetector
 	readabilityExtractor *detect.ReadabilityExtractor
+	markdownConverter    *md.Converter
 }
 
 func NewContentProcessor(imgProcessor *ImageProcessor, appCfg *config.AppConfig, log *slog.Logger) *ContentProcessor {
+	converter := md.NewConverter("", true, nil)
+	converter.Use(plugin.GitHubFlavored())
+
 	return &ContentProcessor{
 		imgProcessor:         imgProcessor,
 		appCfg:               appCfg,
 		log:                  log,
 		detector:             detect.NewContentDetector(log),
 		readabilityExtractor: detect.NewReadabilityExtractor(),
+		markdownConverter:    converter,
 	}
+}
+
+type pageFrontmatter struct {
+	Title       string `yaml:"title"`
+	URL         string `yaml:"url"`
+	CrawledAt   string `yaml:"crawled_at"`
+	ContentHash string `yaml:"content_hash"`
+	Depth       int    `yaml:"depth"`
+}
+
+// buildPageFrontmatter returns a YAML frontmatter block (--- delimited) carrying page
+// metadata for downstream RAG/LLM consumers. The content hash matches the JSONL
+// content_hash since both hash the same markdown body. Returns "" if marshaling fails.
+func buildPageFrontmatter(title, pageURL, body string, depth int) string {
+	fm := pageFrontmatter{
+		Title:     title,
+		URL:       pageURL,
+		CrawledAt: time.Now().Format(time.RFC3339),
+		Depth:     depth,
+	}
+	if len(body) > 0 {
+		fm.ContentHash = utils.CalculateStringSHA256(body)
+	}
+
+	out, err := yaml.Marshal(fm)
+	if err != nil {
+		return ""
+	}
+	return "---\n" + string(out) + "---\n\n"
 }
 
 // ExtractProcessAndSaveContent extracts content using the configured selector, processes images
@@ -44,6 +81,7 @@ func (cp *ContentProcessor) ExtractProcessAndSaveContent(
 	finalURL *url.URL,
 	siteCfg *config.SiteConfig,
 	siteOutputDir string,
+	currentDepth int,
 	taskLog *slog.Logger,
 	ctx context.Context,
 ) (pageTitle string, savedFilePath string, markdownBytes []byte, imageCount int, err error) {
@@ -190,20 +228,7 @@ func (cp *ContentProcessor) ExtractProcessAndSaveContent(
 
 	cp.cleanupHTML(mainContent)
 
-	modifiedHTML, outerHtmlErr := goquery.OuterHtml(mainContent)
-	if outerHtmlErr != nil {
-		err = fmt.Errorf("failed getting modified HTML: %w", outerHtmlErr)
-		taskLog.Error(err.Error())
-		return pageTitle, "", nil, 0, err
-	}
-
-	converter := md.NewConverter("", true, nil)
-	markdownContent, convertErr := converter.ConvertString(modifiedHTML)
-	if convertErr != nil {
-		err = fmt.Errorf("%w: %w", utils.ErrMarkdownConversion, convertErr)
-		taskLog.Error(err.Error())
-		return pageTitle, "", nil, 0, err
-	}
+	markdownContent := cp.markdownConverter.Convert(mainContent)
 
 	outputDirForFile := filepath.Dir(currentPageFullOutputPath)
 	if mkdirErr := os.MkdirAll(outputDirForFile, 0755); mkdirErr != nil {
@@ -212,14 +237,15 @@ func (cp *ContentProcessor) ExtractProcessAndSaveContent(
 		return pageTitle, "", nil, 0, err
 	}
 
-	writeErr := os.WriteFile(currentPageFullOutputPath, []byte(markdownContent), 0644)
+	fileContent := buildPageFrontmatter(pageTitle, finalURL.String(), markdownContent, currentDepth) + markdownContent
+	writeErr := os.WriteFile(currentPageFullOutputPath, []byte(fileContent), 0644)
 	if writeErr != nil {
 		err = fmt.Errorf("%w: saving markdown '%s': %w", utils.ErrFilesystem, currentPageFullOutputPath, writeErr)
 		taskLog.Error(err.Error())
 		return pageTitle, "", nil, 0, err
 	}
 
-	taskLog.Info(fmt.Sprintf("Saved Markdown (%d bytes): %s", len(markdownContent), currentPageFullOutputPath))
+	taskLog.Info(fmt.Sprintf("Saved Markdown (%d bytes): %s", len(fileContent), currentPageFullOutputPath))
 	taskLog.Debug("Content extraction, processing, and saving complete.")
 	return pageTitle, currentPageFullOutputPath, []byte(markdownContent), imgRewriteCount, nil
 }


### PR DESCRIPTION
## Summary

Improves the LLM/RAG-readiness of crawled Markdown and fixes two spots where the tool did not match its own documentation.

## Changes

**Frontmatter metadata on every Markdown file.** Each saved `.md` now begins with a YAML frontmatter block (`title`, `url`, `crawled_at`, `content_hash`, `depth`). Previously the files carried no metadata at all, despite the README claiming a source-URL/timestamp footer. Downstream RAG pipelines can now cite sources, dedupe by hash, and detect staleness without reparsing file paths. The `content_hash` matches the JSONL record's hash (same SHA-256 of the same body), and the JSONL `content` field is unchanged (frontmatter is written only to the `.md` file, not to JSONL).

**Tables are preserved.** The HTML-to-Markdown converter now enables the GitHub-Flavored plugin, so `<table>` renders as a pipe table instead of collapsing into run-together text. Applies to both crawl output and the MCP `get_page` tool. Task lists and strikethrough come along with GFM.

**Faster, single-parse conversion.** Content is converted directly from the already-parsed goquery selection (`Convert`) instead of serializing it back to an HTML string and reparsing it (`OuterHtml` + `ConvertString`), removing one full redundant HTML parse per page. The converter is now built once in `NewContentProcessor` and reused across pages rather than reconstructed per page.

**README accuracy.** Rewrites the output-format section to describe the frontmatter block, notes GitHub-Flavored table support, and fixes the stale `logrus` reference (logging has been `log/slog` since v2.3.0).

## Verification

- `go test ./... -race`: all packages pass
- New test `TestCrawlerRun_FrontmatterAndTables`: asserts the frontmatter fields, that the frontmatter `content_hash` equals the JSONL record's `content_hash`, and that a table renders as a GFM pipe table
- `golangci-lint run ./...`: 0 issues (verified cold cache)
- `gofmt` and `go vet`: clean

## Notes

- On-disk `.md` output format changes (frontmatter is prepended). Consumers that parse the raw `.md` body should skip the leading `---` block. JSONL output is unaffected.
- The incremental-crawl hash fix and the larger RAG features (chunking, MCP content search) are intentionally left for separate PRs.