### PR TITLE
Make incremental crawling re-fetch known pages and detect changes by content region

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,17 @@ Execute the compiled binary from the project root directory:
 ./doc-scraper mcp-server -config config.yaml
 ```
 
+### Incremental Crawling
+
+`crawl -incremental` (which implies `--resume`, and is also what `watch` mode uses) re-fetches every previously-crawled page and re-checks it for changes:
+
+- Change detection is **content-scoped**: it hashes the extracted content-selector region, not the raw page. Churn in the page shell (navigation, analytics, build timestamps, CSRF tokens) outside the content selector does **not** count as a change.
+- Pages whose content region is **unchanged** are skipped without re-converting, re-downloading images, or rewriting output.
+- Pages whose content region **changed** are fully reprocessed and their output is rewritten.
+- A page that now returns an error (e.g. 404) on re-crawl leaves its previously-crawled output **as-is**; nothing is pruned.
+
+Because there is no conditional-request support yet, incremental mode still performs the HTTP fetch for each known page; the savings come from skipping the downstream processing of unchanged pages.
+
 ## Output Structure
 
 Crawled content is saved under the `output_base_dir` defined in the config, organized by domain and preserving the site structure:

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -393,7 +393,9 @@ func (c *Crawler) requeueIncomplete(resume bool, runLog *slog.Logger) (int, erro
 		}
 	}()
 
-	_, _, scanErr := c.store.RequeueIncomplete(c.crawlCtx, requeueChan)
+	// In incremental mode also requeue previously-successful pages so they are
+	// re-fetched and re-checked for content changes.
+	_, _, scanErr := c.store.RequeueIncomplete(c.crawlCtx, requeueChan, c.appCfg.EnableIncremental)
 	close(requeueChan)
 	requeueWg.Wait()
 
@@ -685,7 +687,7 @@ func (c *Crawler) processSinglePageTask(workItem models.WorkItem, workerLog *slo
 	var pageTitle string              // Populated on successful content extraction.
 	var savedContentPath string       // Absolute path to the saved .md file.
 	var normalizedURLString string    // Populated from handleSetupAndResumeCheck.
-	var rawHTMLHash string            // Hash of raw HTML for incremental crawling.
+	var contentHash string            // Hash of the extracted content region for incremental crawling.
 
 	// Deferred function for panic recovery, final status logging, DB update, and WaitGroup decrement.
 	defer func() {
@@ -739,7 +741,7 @@ func (c *Crawler) processSinglePageTask(workItem models.WorkItem, workerLog *slo
 			}
 			if finalStatus == models.PageStatusSuccess { // Mark ProcessedAt only on success
 				pageEntry.ProcessedAt = pageEntry.LastAttempt
-				pageEntry.ContentHash = rawHTMLHash // Store hash for incremental crawling
+				pageEntry.ContentHash = contentHash // Store content-region hash for incremental crawling
 			}
 			// Update page status in the persistent store
 			if dbUpdateErr := c.store.UpdatePageStatus(normalizedURLString, pageEntry); dbUpdateErr != nil {
@@ -801,18 +803,33 @@ func (c *Crawler) processSinglePageTask(workItem models.WorkItem, workerLog *slo
 
 	var parseBodyErr error
 	var originalDoc *goquery.Document
-	originalDoc, rawHTMLHash, parseBodyErr = c.readAndParseBody(resp, finalURL, taskLog) // Closes resp.Body
+	originalDoc, parseBodyErr = c.readAndParseBody(resp, finalURL, taskLog) // Closes resp.Body
 	if handleTaskError(parseBodyErr) {
 		return
 	}
+
+	mainContent, extractedTitle, selectErr := c.contentProcessor.SelectMainContent(originalDoc, finalURL, c.siteCfg, taskLog)
+	if handleTaskError(selectErr) {
+		return
+	}
+	pageTitle = extractedTitle
+
+	// Hash the extracted content region rather than the raw page body so that
+	// page-shell churn (nav, analytics, build timestamps, CSRF tokens) outside the
+	// content selector does not defeat the incremental skip.
+	contentRegionHTML, outerErr := goquery.OuterHtml(mainContent)
+	if handleTaskError(outerErr) {
+		return
+	}
+	contentHash = utils.CalculateStringSHA256(contentRegionHTML)
 
 	if c.appCfg.EnableIncremental {
 		existingHash, exists, hashErr := c.store.GetPageContentHash(normalizedURLString)
 		if hashErr != nil {
 			taskLog.Warn(fmt.Sprintf("Failed to check content hash for incremental crawl: %v", hashErr))
 			// Continue processing despite hash check error
-		} else if exists && existingHash == rawHTMLHash {
-			taskLog.Info("Page unchanged (hash match) - skipping processing")
+		} else if exists && existingHash == contentHash {
+			taskLog.Info("Page content unchanged (hash match) - skipping processing")
 			skipped = true
 			return
 		} else if exists {
@@ -833,16 +850,14 @@ func (c *Crawler) processSinglePageTask(workItem models.WorkItem, workerLog *slo
 		taskLog.Warn(fmt.Sprintf("Non-fatal error encountered during link extraction/queueing: %v", linkErr))
 	}
 
-	var tempPageTitle, tempSavedPath string // Use temp vars for return values from contentProcessor
+	var tempSavedPath string // Temp var for the returned save path from contentProcessor
 	var tempMarkdownBytes []byte
 	var contentErr error
-	// pageTitle and savedContentPath (function-scoped) will be set from these if successful.
-	tempPageTitle, tempSavedPath, tempMarkdownBytes, _, contentErr = c.contentProcessor.ExtractProcessAndSaveContent(originalDoc, finalURL, c.siteCfg, c.siteOutputDir, currentDepth, taskLog, taskCtx)
+	// pageTitle is already set from SelectMainContent above; savedContentPath is set on success.
+	tempSavedPath, tempMarkdownBytes, _, contentErr = c.contentProcessor.ProcessAndSaveContent(mainContent, pageTitle, finalURL, c.siteCfg, c.siteOutputDir, currentDepth, taskLog, taskCtx)
 	if handleTaskError(contentErr) { // If content processing/saving fails, set taskErr and exit.
 		return
 	}
-	// If successful, assign to function-scoped variables for use in defer logging and metadata collection.
-	pageTitle = tempPageTitle
 	savedContentPath = tempSavedPath // This is the ABSOLUTE path to the saved .md file.
 
 	if savedContentPath != "" {
@@ -877,9 +892,12 @@ func (c *Crawler) handleSetupAndResumeCheck(currentURL string, taskLog *slog.Log
 		// Do not return 'err' here; let the crawl attempt proceed if DB check fails.
 		// The error is logged, and status will default to PageStatusNotFound effectively.
 	} else if pageStatus == models.PageStatusSuccess {
-		taskLog.Info("Skipping already successfully processed page (from DB).")
-		shouldSkip = true
-		return parsedURL, normalizedURLStr, host, shouldSkip, nil // Return to skip
+		if !c.appCfg.EnableIncremental {
+			taskLog.Info("Skipping already successfully processed page (from DB).")
+			shouldSkip = true
+			return parsedURL, normalizedURLStr, host, shouldSkip, nil // Return to skip
+		}
+		taskLog.Debug("Re-checking previously processed page for content changes (incremental mode).")
 	} else if pageStatus == models.PageStatusFailure {
 		taskLog.Warn("Retrying previously failed page (from DB).")
 	} else if pageStatus == models.PageStatusPending {
@@ -1059,8 +1077,8 @@ func (c *Crawler) fetchAndValidatePage(reqURLString string, originalParsedURL *u
 
 // readAndParseBody reads the HTTP response body and parses it into a goquery.Document.
 // It ensures resp.Body is closed after reading.
-// Returns the goquery document and the raw HTML hash for incremental crawling.
-func (c *Crawler) readAndParseBody(resp *http.Response, finalURL *url.URL, taskLog *slog.Logger) (doc *goquery.Document, rawHTMLHash string, err error) {
+// Returns the parsed goquery document. Closes resp.Body.
+func (c *Crawler) readAndParseBody(resp *http.Response, finalURL *url.URL, taskLog *slog.Logger) (doc *goquery.Document, err error) {
 	taskLog.Debug(fmt.Sprintf("Reading response body from: %s", finalURL.String()))
 	defer resp.Body.Close() // Ensure response body is closed when this function returns
 
@@ -1069,24 +1087,21 @@ func (c *Crawler) readAndParseBody(resp *http.Response, finalURL *url.URL, taskL
 	limitedReader := io.LimitReader(resp.Body, maxPageSize+1) // +1 to detect exceeding the limit
 	bodyBytes, readErr := io.ReadAll(limitedReader)
 	if readErr != nil {
-		return nil, "", fmt.Errorf("%w: reading body from '%s': %w", utils.ErrResponseBodyRead, finalURL.String(), readErr)
+		return nil, fmt.Errorf("%w: reading body from '%s': %w", utils.ErrResponseBodyRead, finalURL.String(), readErr)
 	}
 	if int64(len(bodyBytes)) > maxPageSize {
-		return nil, "", fmt.Errorf("%w: page '%s' exceeds max size (%d > %d bytes)", utils.ErrResponseBodyRead, finalURL.String(), len(bodyBytes), maxPageSize)
+		return nil, fmt.Errorf("%w: page '%s' exceeds max size (%d > %d bytes)", utils.ErrResponseBodyRead, finalURL.String(), len(bodyBytes), maxPageSize)
 	}
 	taskLog.Debug(fmt.Sprintf("Read %d bytes from response body of %s", len(bodyBytes), finalURL.String()))
-
-	// Calculate hash of raw HTML for incremental crawling
-	rawHTMLHash = utils.CalculateStringSHA256(string(bodyBytes))
 
 	// Parse the HTML content using goquery
 	doc, parseErr := goquery.NewDocumentFromReader(bytes.NewReader(bodyBytes))
 	if parseErr != nil {
-		return nil, rawHTMLHash, fmt.Errorf("%w: parsing HTML from '%s': %w", utils.ErrParsing, finalURL.String(), parseErr)
+		return nil, fmt.Errorf("%w: parsing HTML from '%s': %w", utils.ErrParsing, finalURL.String(), parseErr)
 	}
 
 	taskLog.Debug("Successfully parsed HTML into goquery document.")
-	return doc, rawHTMLHash, nil
+	return doc, nil
 }
 
 // extractLinksAndImages extracts markdown links and image references from markdown content.

--- a/pkg/crawler/crawler_run_test.go
+++ b/pkg/crawler/crawler_run_test.go
@@ -424,3 +424,159 @@ func TestCrawlerRun_FrontmatterAndTables(t *testing.T) {
 		t.Errorf("frontmatter content_hash %q must match JSONL content_hash %q", fm.ContentHash, jsonlHash)
 	}
 }
+
+// mutableDocServer serves per-path HTML that tests can change between crawls, and
+// counts hits per path so incremental re-fetch behavior can be asserted.
+type mutableDocServer struct {
+	mu   sync.Mutex
+	body map[string]string
+	hits map[string]int
+}
+
+func newMutableDocServer(t *testing.T) (*httptest.Server, *mutableDocServer) {
+	t.Helper()
+	ms := &mutableDocServer{body: map[string]string{}, hits: map[string]int{}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ms.mu.Lock()
+		ms.hits[r.URL.Path]++
+		body, ok := ms.body[r.URL.Path]
+		ms.mu.Unlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, ms
+}
+
+func (m *mutableDocServer) set(path, body string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.body[path] = body
+}
+
+func (m *mutableDocServer) remove(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.body, path)
+}
+
+func (m *mutableDocServer) hitCount(path string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.hits[path]
+}
+
+// runResumableCrawl drives Crawler.Run with an explicit resume flag, reusing the
+// same StateDir/OutputBaseDir across calls so incremental re-crawls see prior state.
+func runResumableCrawl(t *testing.T, appCfg *config.AppConfig, siteCfg *config.SiteConfig, resume bool) {
+	t.Helper()
+	logger := silentLogger()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	store, err := storage.NewBadgerStore(ctx, appCfg.StateDir, siteCfg.AllowedDomain, resume, logger)
+	require.NoError(t, err)
+	defer store.Close()
+	httpClient := fetch.NewClient(appCfg.HTTPClientSettings, logger)
+	fetcher := fetch.NewFetcher(httpClient, appCfg, logger)
+	rl := fetch.NewRateLimiter(appCfg.DefaultDelayPerHost, logger)
+	c, err := NewCrawler(appCfg, siteCfg, "testsite", logger, store, fetcher, rl, ctx, cancel, resume)
+	require.NoError(t, err)
+	require.NoError(t, c.Run(resume))
+}
+
+func mdFileIn(t *testing.T, dir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".md") {
+			return filepath.Join(dir, e.Name())
+		}
+	}
+	t.Fatalf("no .md file found in %s", dir)
+	return ""
+}
+
+// TestCrawlerRun_IncrementalContentScoped is the regression test for content-scoped
+// incremental crawling: an incremental re-crawl re-fetches known pages, skips
+// reprocessing when only the page shell changed, and reprocesses when the content
+// selector region actually changed.
+func TestCrawlerRun_IncrementalContentScoped(t *testing.T) {
+	server, ms := newMutableDocServer(t)
+	page := func(content, shell string) string {
+		return `<html><head><title>Doc</title></head><body>` +
+			`<main id="c">` + content + `</main>` +
+			`<footer>` + shell + `</footer></body></html>`
+	}
+	ms.set("/docs/index.html", page("<p>ORIGINAL</p>", "built at T0"))
+
+	appCfg := newTestAppConfig(t)
+	appCfg.EnableIncremental = true
+	appCfg.StateDir = t.TempDir()
+	appCfg.OutputBaseDir = t.TempDir()
+	siteCfg := baseSiteConfig(server, "/docs/index.html")
+	siteCfg.ContentSelector = "#c"
+
+	// Crawl 1 (fresh).
+	runResumableCrawl(t, appCfg, siteCfg, false)
+	md := mdFileIn(t, siteOutputDir(appCfg, siteCfg))
+	info1, err := os.Stat(md)
+	require.NoError(t, err)
+	body1, err := os.ReadFile(md)
+	require.NoError(t, err)
+	require.Contains(t, string(body1), "ORIGINAL")
+	require.Equal(t, 1, ms.hitCount("/docs/index.html"))
+
+	// Crawl 2: change ONLY the shell (outside #c). Content unchanged -> must re-fetch but NOT rewrite.
+	ms.set("/docs/index.html", page("<p>ORIGINAL</p>", "built at T1-completely-different-shell"))
+	runResumableCrawl(t, appCfg, siteCfg, true)
+	info2, err := os.Stat(md)
+	require.NoError(t, err)
+	assert.Equal(t, 2, ms.hitCount("/docs/index.html"), "incremental must re-fetch the known page")
+	assert.Equal(t, info1.ModTime().UnixNano(), info2.ModTime().UnixNano(),
+		"shell-only change must NOT rewrite the .md (content-scoped hash unchanged)")
+
+	// Crawl 3: change the CONTENT inside #c -> must reprocess and rewrite.
+	ms.set("/docs/index.html", page("<p>UPDATED CONTENT</p>", "built at T2"))
+	runResumableCrawl(t, appCfg, siteCfg, true)
+	info3, err := os.Stat(md)
+	require.NoError(t, err)
+	body3, err := os.ReadFile(md)
+	require.NoError(t, err)
+	assert.Equal(t, 3, ms.hitCount("/docs/index.html"))
+	assert.Contains(t, string(body3), "UPDATED CONTENT", "changed content must be rewritten")
+	assert.NotContains(t, string(body3), "ORIGINAL")
+	assert.NotEqual(t, info1.ModTime().UnixNano(), info3.ModTime().UnixNano(),
+		"changed content must rewrite the .md")
+}
+
+// TestCrawlerRun_Incremental404LeavesOutput verifies that when a previously-crawled
+// page returns 404 on an incremental re-crawl, its existing output is left as-is.
+func TestCrawlerRun_Incremental404LeavesOutput(t *testing.T) {
+	server, ms := newMutableDocServer(t)
+	ms.set("/docs/index.html", `<html><head><title>Doc</title></head><body><main id="c"><p>KEEP ME</p></main></body></html>`)
+
+	appCfg := newTestAppConfig(t)
+	appCfg.EnableIncremental = true
+	appCfg.StateDir = t.TempDir()
+	appCfg.OutputBaseDir = t.TempDir()
+	siteCfg := baseSiteConfig(server, "/docs/index.html")
+	siteCfg.ContentSelector = "#c"
+
+	runResumableCrawl(t, appCfg, siteCfg, false)
+	md := mdFileIn(t, siteOutputDir(appCfg, siteCfg))
+	require.FileExists(t, md)
+
+	// Page now 404s on the incremental re-crawl.
+	ms.remove("/docs/index.html")
+	runResumableCrawl(t, appCfg, siteCfg, true) // must not fail the crawl
+
+	assert.FileExists(t, md, "existing output must be left as-is when a page now 404s")
+	body, err := os.ReadFile(md)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "KEEP ME", "previously-crawled content must be preserved")
+}

--- a/pkg/process/content.go
+++ b/pkg/process/content.go
@@ -74,26 +74,22 @@ func buildPageFrontmatter(title, pageURL, body string, depth int) string {
 	return "---\n" + string(out) + "---\n\n"
 }
 
-// ExtractProcessAndSaveContent extracts content using the configured selector, processes images
-// and internal links, converts to Markdown, and saves to a path derived from finalURL and siteOutputDir.
-func (cp *ContentProcessor) ExtractProcessAndSaveContent(
+// SelectMainContent resolves the page title and extracts the main content selection
+// using the configured selector, framework auto-detection, or the readability
+// fallback. It performs no image processing, conversion, or writing, so callers can
+// hash the returned selection before deciding whether to process the page.
+func (cp *ContentProcessor) SelectMainContent(
 	doc *goquery.Document,
 	finalURL *url.URL,
 	siteCfg *config.SiteConfig,
-	siteOutputDir string,
-	currentDepth int,
 	taskLog *slog.Logger,
-	ctx context.Context,
-) (pageTitle string, savedFilePath string, markdownBytes []byte, imageCount int, err error) {
-	taskLog.Debug("Extracting, processing, and saving content.")
-
+) (mainContent *goquery.Selection, pageTitle string, err error) {
 	pageTitle = strings.TrimSpace(doc.Find("title").First().Text())
 	if pageTitle == "" {
 		pageTitle = "Untitled Page"
 	}
 	taskLog = taskLog.With("page_title", pageTitle)
 
-	var mainContent *goquery.Selection
 	var actualSelector string
 
 	if detect.IsAutoSelector(siteCfg.ContentSelector) {
@@ -105,7 +101,7 @@ func (cp *ContentProcessor) ExtractProcessAndSaveContent(
 			if extractErr != nil {
 				err = fmt.Errorf("%w: readability failed for '%s': %v", utils.ErrContentSelector, finalURL.String(), extractErr) //nolint:errorlint // extractErr is supplemental
 				taskLog.Warn(err.Error())
-				return pageTitle, "", nil, 0, err
+				return nil, pageTitle, err
 			}
 			mainContent = extractedContent
 			if extractedTitle != "" {
@@ -128,12 +124,11 @@ func (cp *ContentProcessor) ExtractProcessAndSaveContent(
 						utils.ErrContentSelector, actualSelector, finalURL.String(), extractErr, //nolint:errorlint // extractErr is supplemental
 					)
 					taskLog.Warn(err.Error())
-					return pageTitle, "", nil, 0, err
+					return nil, pageTitle, err
 				}
 				mainContent = extractedContent
 				if extractedTitle != "" {
 					pageTitle = extractedTitle
-					taskLog = taskLog.With("page_title", pageTitle)
 				}
 			} else {
 				mainContent = mainContentSelection.First().Clone()
@@ -144,17 +139,35 @@ func (cp *ContentProcessor) ExtractProcessAndSaveContent(
 		if mainContentSelection.Length() == 0 {
 			err = fmt.Errorf("%w: selector '%s' not found on page '%s'", utils.ErrContentSelector, siteCfg.ContentSelector, finalURL.String())
 			taskLog.Warn(err.Error())
-			return pageTitle, "", nil, 0, err
+			return nil, pageTitle, err
 		}
 		mainContent = mainContentSelection.First().Clone()
 		taskLog.Debug(fmt.Sprintf("Found main content using selector '%s'", siteCfg.ContentSelector))
 	}
 
+	return mainContent, pageTitle, nil
+}
+
+// ProcessAndSaveContent processes images and internal links on the already-selected
+// main content, converts it to Markdown, prepends YAML frontmatter, and writes the
+// file to a path derived from finalURL and siteOutputDir.
+func (cp *ContentProcessor) ProcessAndSaveContent(
+	mainContent *goquery.Selection,
+	pageTitle string,
+	finalURL *url.URL,
+	siteCfg *config.SiteConfig,
+	siteOutputDir string,
+	currentDepth int,
+	taskLog *slog.Logger,
+	ctx context.Context,
+) (savedFilePath string, markdownBytes []byte, imageCount int, err error) {
+	taskLog = taskLog.With("page_title", pageTitle)
+
 	currentPageFullOutputPath, pageInScope := cp.getOutputPathForURL(finalURL, siteCfg, siteOutputDir)
 	if !pageInScope {
 		err = fmt.Errorf("%w: output path calculation failed unexpectedly for in-scope URL '%s'", utils.ErrScopeViolation, finalURL.String())
 		taskLog.Error(err.Error())
-		return pageTitle, "", nil, 0, err
+		return "", nil, 0, err
 	}
 
 	currentPageOutputDir := filepath.Dir(currentPageFullOutputPath)
@@ -234,7 +247,7 @@ func (cp *ContentProcessor) ExtractProcessAndSaveContent(
 	if mkdirErr := os.MkdirAll(outputDirForFile, 0755); mkdirErr != nil {
 		err = fmt.Errorf("%w: creating output directory '%s': %w", utils.ErrFilesystem, outputDirForFile, mkdirErr)
 		taskLog.Error(err.Error())
-		return pageTitle, "", nil, 0, err
+		return "", nil, 0, err
 	}
 
 	fileContent := buildPageFrontmatter(pageTitle, finalURL.String(), markdownContent, currentDepth) + markdownContent
@@ -242,12 +255,12 @@ func (cp *ContentProcessor) ExtractProcessAndSaveContent(
 	if writeErr != nil {
 		err = fmt.Errorf("%w: saving markdown '%s': %w", utils.ErrFilesystem, currentPageFullOutputPath, writeErr)
 		taskLog.Error(err.Error())
-		return pageTitle, "", nil, 0, err
+		return "", nil, 0, err
 	}
 
 	taskLog.Info(fmt.Sprintf("Saved Markdown (%d bytes): %s", len(fileContent), currentPageFullOutputPath))
 	taskLog.Debug("Content extraction, processing, and saving complete.")
-	return pageTitle, currentPageFullOutputPath, []byte(markdownContent), imgRewriteCount, nil
+	return currentPageFullOutputPath, []byte(markdownContent), imgRewriteCount, nil
 }
 
 // getOutputPathForURL maps a crawled URL to a sanitized local filesystem path, performing scope

--- a/pkg/storage/badger_store.go
+++ b/pkg/storage/badger_store.go
@@ -360,7 +360,7 @@ func (s *BadgerStore) RunGC(ctx context.Context, interval time.Duration) {
 	}
 }
 
-func (s *BadgerStore) RequeueIncomplete(ctx context.Context, workChan chan<- models.WorkItem) (int, int, error) {
+func (s *BadgerStore) RequeueIncomplete(ctx context.Context, workChan chan<- models.WorkItem, includeSuccess bool) (int, int, error) {
 	s.log.Info("Resume Mode: Scanning database for incomplete tasks to requeue...")
 	requeuedCount := 0
 	scanErrors := 0
@@ -405,7 +405,8 @@ func (s *BadgerStore) RequeueIncomplete(ctx context.Context, workChan chan<- mod
 						scanErrors++
 						return nil
 					}
-					if entry.Status == models.PageStatusFailure || entry.Status == models.PageStatusPending {
+					if entry.Status == models.PageStatusFailure || entry.Status == models.PageStatusPending ||
+						(includeSuccess && entry.Status == models.PageStatusSuccess) {
 						s.log.Debug("Resume scan: requeueing", "url", urlToRequeue, "status", entry.Status, "depth", entry.Depth)
 						shouldRequeue = true
 						requeueDepth = entry.Depth

--- a/pkg/storage/badger_store_test.go
+++ b/pkg/storage/badger_store_test.go
@@ -443,7 +443,7 @@ func TestRequeueIncomplete(t *testing.T) {
 	t.Run("empty store", func(t *testing.T) {
 		store := newTestStore(t)
 		ch := make(chan models.WorkItem, 10)
-		requeued, scanErrors, err := store.RequeueIncomplete(context.Background(), ch)
+		requeued, scanErrors, err := store.RequeueIncomplete(context.Background(), ch, false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, requeued)
 		assert.Equal(t, 0, scanErrors)
@@ -457,7 +457,7 @@ func TestRequeueIncomplete(t *testing.T) {
 			LastAttempt: time.Now(),
 		})
 		ch := make(chan models.WorkItem, 10)
-		requeued, _, err := store.RequeueIncomplete(context.Background(), ch)
+		requeued, _, err := store.RequeueIncomplete(context.Background(), ch, false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, requeued)
 		assert.Empty(t, ch)
@@ -468,7 +468,7 @@ func TestRequeueIncomplete(t *testing.T) {
 		// Mark page (creates empty value = pending)
 		store.MarkPageVisited("https://example.com/pending1")
 		ch := make(chan models.WorkItem, 10)
-		requeued, _, err := store.RequeueIncomplete(context.Background(), ch)
+		requeued, _, err := store.RequeueIncomplete(context.Background(), ch, false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, requeued)
 		item := <-ch
@@ -484,7 +484,7 @@ func TestRequeueIncomplete(t *testing.T) {
 			LastAttempt: time.Now(),
 		})
 		ch := make(chan models.WorkItem, 10)
-		requeued, _, err := store.RequeueIncomplete(context.Background(), ch)
+		requeued, _, err := store.RequeueIncomplete(context.Background(), ch, false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, requeued)
 		item := <-ch
@@ -499,7 +499,7 @@ func TestRequeueIncomplete(t *testing.T) {
 			ErrorType: "network",
 		})
 		ch := make(chan models.WorkItem, 10)
-		requeued, _, err := store.RequeueIncomplete(context.Background(), ch)
+		requeued, _, err := store.RequeueIncomplete(context.Background(), ch, false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, requeued)
 		assert.Empty(t, ch)
@@ -514,8 +514,24 @@ func TestRequeueIncomplete(t *testing.T) {
 		cancel() // cancel immediately
 
 		ch := make(chan models.WorkItem, 10)
-		_, _, err := store.RequeueIncomplete(ctx, ch)
+		_, _, err := store.RequeueIncomplete(ctx, ch, false)
 		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("success requeued when includeSuccess is true", func(t *testing.T) {
+		store := newTestStore(t)
+		store.UpdatePageStatus("https://example.com/done", &models.PageDBEntry{
+			Status:      models.PageStatusSuccess,
+			Depth:       2,
+			LastAttempt: time.Now(),
+		})
+		ch := make(chan models.WorkItem, 10)
+		requeued, _, err := store.RequeueIncomplete(context.Background(), ch, true)
+		require.NoError(t, err)
+		assert.Equal(t, 1, requeued)
+		item := <-ch
+		assert.Equal(t, "https://example.com/done", item.URL)
+		assert.Equal(t, 2, item.Depth)
 	})
 }
 

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -42,9 +42,10 @@ type StoreAdmin interface {
 	// GetVisitedCount returns an approximate count of all keys in the store
 	GetVisitedCount() (int, error)
 
-	// RequeueIncomplete scans the DB and sends incomplete items (failed, pending, empty) to the provided channel
-	// Should be called only during resume
-	RequeueIncomplete(ctx context.Context, workChan chan<- models.WorkItem) (requeuedCount int, scanErrors int, err error)
+	// RequeueIncomplete scans the DB and sends incomplete items (failed, pending, empty) to the provided channel.
+	// When includeSuccess is true (incremental crawls), successfully-processed pages are also requeued so they can
+	// be re-fetched and re-checked for content changes. Should be called only during resume.
+	RequeueIncomplete(ctx context.Context, workChan chan<- models.WorkItem, includeSuccess bool) (requeuedCount int, scanErrors int, err error)
 
 	// RunGC runs periodic garbage collection. Should be run in a goroutine
 	RunGC(ctx context.Context, interval time.Duration)


### PR DESCRIPTION
### Summary
Makes -incremental (and watch mode, which uses it) actually detect changed pages. Previously the feature stored content hashes it never meaningfully compared, so an incremental re-crawl never re-fetched already-crawled pages and could not pick up any content change.

### The bug (verified empirically)
A two-crawl experiment: crawl a page, then completely change its content and re-crawl with -incremental. The already-crawled page was never re-fetched, and the change was never detected. Root cause was two layers:

1. Comparison never ran. On a resumed/incremental crawl, Success pages are neither re-queued (RequeueIncomplete only requeued Failure/Pending) nor re-fetched (handleSetupAndResumeCheck skipped Success before fetching). The only pages
that got fetched had no stored hash, so the existingHash == hash branch was effectively dead.
2. Wrong hash. Even where it could fire, the hash was over the raw page body, so page-shell churn (nav, analytics, build timestamps, CSRF tokens) counted as a content change.

### The fix
- Re-queue previously-successful pages in incremental mode so they are re-fetched and re-checked (RequeueIncomplete gains an includeSuccess flag; handleSetupAndResumeCheck no longer skips Success when incremental is enabled).
- Content-scoped change detection. The incremental hash is now a SHA-256 of the extracted content-selector region, not the raw page. Shell churn outside the selector no longer defeats the skip.
- Split ExtractProcessAndSaveContent into SelectMainContent + ProcessAndSaveContent (SRP) so the content hash can be computed right after selection, letting the skip decision happen before the expensive image-download / convert / write work.
- Pages that now error (e.g. 404) on re-crawl leave their existing output as-is — nothing is pruned.

Net behavior: an incremental crawl re-fetches known pages, skips reprocessing pages whose content region is unchanged, and fully reprocesses changed ones. (Re-fetching is still performed; conditional-request support to skip even the fetch is a separate, larger enhancement.)

### Verification
- go test ./... -race: all packages pass
- New TestCrawlerRun_IncrementalContentScoped: proves a shell-only change re-fetches but does not rewrite the .md (content-scoped skip), while a content-region change does reprocess and rewrite it
- New TestCrawlerRun_Incremental404LeavesOutput: proves a page that now 404s leaves its prior output intact
- New store test: RequeueIncomplete(..., includeSuccess=true) requeues Success pages
- golangci-lint run ./...: 0 issues (cold cache); gofmt and go vet clean

### Notes
- Builds on the content-scoped hash and converter work from the prior PR.
- No new config knob: raw-page hashing was a defect, not an option worth preserving.