### PR TITLE
Fix JSONL finalization on Windows

### DIFF
--- a/pkg/crawler/output.go
+++ b/pkg/crawler/output.go
@@ -377,7 +377,13 @@ func (om *OutputManager) rewriteFinalizedJSONL(spans map[string]pageSpan) error 
 	if err != nil {
 		return fmt.Errorf("open source: %w", err)
 	}
-	defer src.Close()
+
+	srcClosed := false
+	defer func() {
+		if !srcClosed {
+			_ = src.Close()
+		}
+	}()
 
 	tmpPath := om.jsonlFilePath + ".tmp"
 	tmp, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
@@ -435,6 +441,11 @@ func (om *OutputManager) rewriteFinalizedJSONL(spans map[string]pageSpan) error 
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close temp: %w", err)
 	}
+	if err := src.Close(); err != nil {
+		return fmt.Errorf("close source: %w", err)
+	}
+	srcClosed = true
+
 	if err := os.Rename(tmpPath, om.jsonlFilePath); err != nil {
 		return fmt.Errorf("rename temp: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes JSONL finalization on Windows by closing both the temporary output file and the source `pages.jsonl` file before replacing the existing JSONL file.

## Problem

On Windows, a crawl with JSONL output enabled could successfully crawl and save pages but fail during finalization with an error similar to:

```text
Failed to write finalized JSONL
rename ...pages.jsonl.tmp ...pages.jsonl: Access is denied.
```

`rewriteFinalizedJSONL` kept the source `pages.jsonl` handle open until the function returned while attempting to replace that file with `os.Rename`.

Windows prevents the replacement while the relevant file handle remains open.

## Fix

* Explicitly close the temporary JSONL file before the rename.
* Explicitly close the source `pages.jsonl` file before the rename.
* Retain guarded deferred cleanup so both files are still closed correctly on earlier error paths.

The finalization sequence is therefore:

```text
flush temp
→ sync temp
→ close temp
→ close source
→ rename temp over pages.jsonl
```

## Verification

Tested on Windows.

The targeted JSONL finalization test passes:

```text
go test ./pkg/crawler -run TestFinalizeJSONL_DedupesAndSortsByURL -v
```

The complete crawler package test suite also passes:

```text
go test ./pkg/crawler -v
```

I additionally verified the change with a real documentation crawl that previously reproduced the issue. The crawl completed successfully and the finalized `pages.jsonl` ended with the expected `crawl_meta` record:

```text
record_type    : crawl_meta
site_key       : tulip_python_docs
allowed_domain : tulip.labri.fr
total_pages    : 16
```

### Full test-suite note

Running `go test ./...` on the same Windows environment passes the crawler package and the other packages except for the unrelated MCP test `TestHandleDescribeServer_IncludesRecentJobsNewestFirst`. This change does not modify the MCP package.